### PR TITLE
Fix user amount display for all users

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -326,7 +326,7 @@
                                     <div class="card-header bg-primary text-white">Loan Details</div>
                                     <div class="card-body">
                                         <p><strong>City:</strong> ${d.city || 'N/A'}</p>
-                                        <p><strong>Amount:</strong> TShs ${d.amount ? d.amount.toLocaleString() : 'N/A'}</p>
+                                        <p><strong>Amount:</strong> TShs ${(d.loanAmount ?? d.amount) ? (d.loanAmount ?? d.amount).toLocaleString() : 'N/A'}</p>
                                         <p><strong>Interest Rate:</strong> ${d.interestRate || 'N/A'}%</p>
                                         <p><strong>Processing Fee:</strong> TShs ${d.processingFee ? d.processingFee.toLocaleString() : 'N/A'}</p>
                                         <p><strong>Total Amount:</strong> TShs ${d.totalAmount ? d.totalAmount.toLocaleString() : 'N/A'}</p>
@@ -340,7 +340,7 @@
                                 <div class="card mb-3">
                                     <div class="card-header bg-primary text-white">Collateral Details</div>
                                     <div class="card-body">
-                                        <p><strong>Collateral:</strong> ${d.collateral || 'N/A'}</p>
+                                        <p><strong>Collateral:</strong> ${d.collateralType === 'OTHER' ? (d.otherCollateral || 'Other') : (d.collateralType || 'N/A')}</p>
                                         <p><strong>Device RAM:</strong> ${d.ram || 'N/A'}</p>
                                         <p><strong>Device Storage:</strong> ${d.storage || 'N/A'}</p>
                                         <p><strong>Device Brand:</strong> ${d.brand || 'N/A'}</p>
@@ -620,7 +620,7 @@
                     tr.innerHTML = `
                         <td>${data.city || 'N/A'}</td>
                         <td>${truncateName(data.name)}</td>
-                        <td>${formatAmount(data.amount)}</td>
+                        <td>${formatAmount((data.loanAmount ?? data.amount))}</td>
                         <td>${statusBadge(data.status)}</td>
                         <td>
                             <div class="d-flex justify-content-start align-items-center">
@@ -707,12 +707,12 @@
                         d.name,
                         d.contact,
                         d.university,
-                        d.collateral,
+                        (d.collateralType === 'OTHER' ? (d.otherCollateral || 'Other') : (d.collateralType || '')),
                         q.condition,
                         q.hasReceipt,
                         q.serialNumber,
                         q.estimatedValue,
-                        d.amount,
+                        (d.loanAmount ?? d.amount),
                         d.interestRate,
                         d.processingFee,
                         d.totalAmount,

--- a/user.html
+++ b/user.html
@@ -734,7 +734,7 @@
                 const rowHtml = `
                     <tr>
                       <td>${dateStr}</td>
-                      <td>${data.amount}</td>
+                      <td>${(data.loanAmount ?? data.amount) ? `TShs ${(data.loanAmount ?? data.amount).toLocaleString()}` : 'N/A'}</td>
                       <td>${statusBadge(data.status)}</td>
                       <td>${data.message || ''}</td>
                     </tr>`;


### PR DESCRIPTION
Fixes "N/A" for loan amounts and incorrect collateral display in user and admin views.

The application was saving loan amounts as `loanAmount` but displaying `amount`, and collateral logic was not correctly handling `collateralType` and `otherCollateral`. This PR aligns the display fields to match the saved data.

---
<a href="https://cursor.com/background-agent?bcId=bc-5a7a0dbb-6cfb-4303-b5dd-a5d944f2aebc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5a7a0dbb-6cfb-4303-b5dd-a5d944f2aebc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

