### PR TITLE
Remove registration number and fix N/A display

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -299,7 +299,6 @@
                                     <div class="card-body">
                                         <p><strong>Name:</strong> ${d.name || 'N/A'}</p>
                                         <p><strong>University:</strong> ${d.university || 'N/A'}</p>
-                                        <p><strong>Registration Number:</strong> ${d.regNumber || 'N/A'}</p>
                                         <p><strong>NIDA:</strong> ${d.nida || 'N/A'}</p>
                                         <p><strong>Contact:</strong> ${d.contact || 'N/A'}</p>
                                         <p><strong>Address:</strong> ${d.place || 'N/A'}</p>

--- a/user.html
+++ b/user.html
@@ -925,6 +925,8 @@
                     brand: document.getElementById(`${prefix}-brand`).value,
                     ram: document.getElementById(`${prefix}-ram`).value,
                     storage: document.getElementById(`${prefix}-storage`).value,
+                    startDate: document.getElementById(`${prefix}-start-date`).value,
+                    endDate: document.getElementById(`${prefix}-end-date`).value,
                     payment: {
                         method: document.getElementById(`${prefix}-payment-method`).value,
                         account: document.getElementById(`${prefix}-payment-account`).value,


### PR DESCRIPTION
Remove the registration number from `admin.html` and add `startDate` and `endDate` to loan submissions to ensure they display correctly.

The `startDate` and `endDate` fields were showing "N/A" in the admin view because they were not being saved as part of the loan data during submission. This change ensures these fields are captured and displayed.

---
<a href="https://cursor.com/background-agent?bcId=bc-30a03956-84a3-4f25-a443-eab16d248746">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-30a03956-84a3-4f25-a443-eab16d248746">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

